### PR TITLE
Replacing open_uri by open_uri_redirections to allow http->https safe…

### DIFF
--- a/lib/codename/lister/adjectives_lister.rb
+++ b/lib/codename/lister/adjectives_lister.rb
@@ -1,13 +1,13 @@
 require 'rubygems'
 require 'nokogiri'
-require 'open-uri'
+require 'open_uri_redirections'
 
 module Codename::Lister
   class AdjectivesLister < BaseLister
     URL = "http://www.esldesk.com/content/voc/adjectives.js"
 
     def list
-      doc = open(URL).read
+      doc = open(URL, :allow_redirections => :safe).read
       doc.split("\n").collect {|line| line.match(/\"(.+);\"/)[1] rescue nil }.compact
     end
     

--- a/lib/codename/lister/colors_lister.rb
+++ b/lib/codename/lister/colors_lister.rb
@@ -1,13 +1,13 @@
 require 'rubygems'
 require 'nokogiri'
-require 'open-uri'
+require 'open_uri_redirections'
 
 module Codename::Lister
   class ColorsLister < BaseLister
     URL = "http://www.colordic.org/y/"
 
     def list
-      doc = Nokogiri::HTML(open(URL))
+      doc = Nokogiri::HTML(open(URL, :allow_redirections => :safe))
       doc.css("table.colortable td a span").collect { |node| node.text }
     end
     

--- a/lib/codename/lister/cyclones_lister.rb
+++ b/lib/codename/lister/cyclones_lister.rb
@@ -1,13 +1,13 @@
 require 'rubygems'
 require 'nokogiri'
-require 'open-uri'
+require 'open_uri_redirections'
 
 module Codename::Lister
   class CyclonesLister < BaseLister
     URL = "http://www.jma.go.jp/jma/jma-eng/jma-center/rsmc-hp-pub-eg/tyname.html"
 
     def list
-      doc = Nokogiri::HTML(open(URL))
+      doc = Nokogiri::HTML(open(URL, :allow_redirections => :safe))
       doc.xpath("/html/body/table[3]/tr").collect do |rows|
         columns = rows.css("td")
         columns.shift

--- a/lib/codename/lister/elements_lister.rb
+++ b/lib/codename/lister/elements_lister.rb
@@ -1,13 +1,13 @@
 require 'rubygems'
 require 'nokogiri'
-require 'open-uri'
+require 'open_uri_redirections'
 
 module Codename::Lister
   class ElementsLister < BaseLister
     URL = "http://en.wikipedia.org/wiki/List_of_elements"
 
     def list
-      doc = Nokogiri::HTML(open(URL))
+      doc = Nokogiri::HTML(open(URL, :allow_redirections => :safe))
       doc.css("table.wikitable tr > td[3] > a[1]").collect { |node| node.text }
     end
     

--- a/lib/codename/lister/stars_lister.rb
+++ b/lib/codename/lister/stars_lister.rb
@@ -1,13 +1,13 @@
 require 'rubygems'
 require 'nokogiri'
-require 'open-uri'
+require 'open_uri_redirections'
 
 module Codename::Lister
   class StarsLister < BaseLister
     URL = "http://en.wikipedia.org/wiki/List_of_constellations"
 
     def list
-      doc = Nokogiri::HTML(open(URL))
+      doc = Nokogiri::HTML(open(URL, :allow_redirections => :safe))
       doc.css("table.wikitable tr > td[1] > a[1]").collect { |node| node.text }
     end
     


### PR DESCRIPTION
… redirections

This gem contains outdated URLs for the sources it relies to pull data from.
These outdated URLs are unsafe and wikipedia started to adopt https by default.
The http gem used in this project (open_uri) doesn't support redirects. open_uri_redirections patches that.
